### PR TITLE
Improve gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 src/test_cleanup.sh
 src/test_reindex.sh
+src/node_modules
+package-lock.json


### PR DESCRIPTION
Hi, I added two paths inside the gitignore file. 

One is for the folder of the node dependencies downloaded with npm install and the other one is to ignore the file with the version of the repos taken during the installation.

Note: For the last one, I prefer to specify the version inside the package.json file and don't push the lock; I don't know if it is the same for you. It is something related to https://github.com/DivanteLtd/mage2nosql/issues/2#issuecomment-334004063